### PR TITLE
Separate server from client

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,21 +8,17 @@
   },
   "dependencies": {
     "axios": "^0.15.3",
-    "body-parser": "^1.8.1",
-    "express": "^4.9.0",
-    "mongoose": "~3.6.13",
-    "pg": "^6.1.2",
-    "pg-hstore": "^2.3.2",
     "react": "15.4.1",
     "react-addons-shallow-compare": "^15.4.1",
     "react-native": "0.39.2",
     "react-native-autolink": "^0.10.0",
     "react-native-button": "^1.7.1",
+    "react-native-hideable-view": "^1.0.3",
     "react-native-router-flux": "^3.37.0",
+    "react-native-search-bar": "^2.16.0",
     "react-native-tabs": "^1.0.9",
     "react-native-toggle": "^1.0.3",
-    "react-native-vector-icons": "^3.0.0",
-    "sequelize": "^3.30.0"
+    "react-native-vector-icons": "^3.0.0"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies" : {
+    "body-parser": "^1.8.1",
+    "express": "^4.9.0",
+    "mongoose": "~3.6.13",
+    "pg": "^6.1.2",
+    "pg-hstore": "^2.3.2",
+    "sequelize": "^3.30.0"
+  },
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
You actually need two npm packages.

One is the normal one in the root of your project.

The other is in server/

Now you can run your react-native app the normal way `react-native run-ios`. You can start the server by running `cd server` then `node index.js`.
